### PR TITLE
Replaced "cp" by "lizardfs makesnapshot" for instantaneous snapshot creation

### DIFF
--- a/snap_create
+++ b/snap_create
@@ -81,7 +81,7 @@ if [ ! -d "${SNAP_DIR}" ]; then
 fi
 
 # Copy current state to a new snapshot
-cp "${CURRENT_PATH}" "${SNAP_PATH}"
+lizardfs makesnapshot -o "${CURRENT_PATH}" "${SNAP_PATH}"
 EOT
 )
 

--- a/snap_revert
+++ b/snap_revert
@@ -72,7 +72,7 @@ SNAP_PATH="${SNAP_DIR}/${SNAP_ID}"
 SNAP_PATH_RELATIVE=$(basename ${SNAP_PATH})
 CURRENT_PATH=${DISK_PATH}
 
-CMD="rm \"${CURRENT_PATH}\" ; cp \"${SNAP_PATH}\" \"${CURRENT_PATH}\""
+CMD="rm \"${CURRENT_PATH}\" ; lizardfs makesnapshot -o \"${SNAP_PATH}\" \"${CURRENT_PATH}\""
 
 ssh_exec_and_log "${SRC_HOST}" "${CMD}" \
                  "Error reverting snapshot to ${SNAP_PATH}"


### PR DESCRIPTION
Now the snapshot create and revert are instantaneous as lazy copy is used.