### PR TITLE
Fixed save_as snapshot creation

### DIFF
--- a/cpds
+++ b/cpds
@@ -89,7 +89,7 @@ DST_READLN=\$($READLINK -f $DST_PATH)
 if [ \( -L $SRC_PATH \) -a \( "\$SRC_READLN" = "\$DST_READLN" \) ] ; then
     echo "Not copying files to image repo, they are the same"
 else
-    lizardfs makesnapshot $SRC_PATH $DST_PATH
+    lizardfs makesnapshot \$SRC_READLN $DST_PATH
 fi
 EOF
 )


### PR DESCRIPTION
Symlinks of instance's persistent disk MUST be resolved first, otherwise only symlink is copied. Then it leads to data corruption as 2 different images points to the same data.